### PR TITLE
Use app version as a part of the container name.

### DIFF
--- a/asyncy/Containers.py
+++ b/asyncy/Containers.py
@@ -171,7 +171,7 @@ class Containers:
         # of the hash and a hyphen. K8s names must be < 63 chars.
         simple_name = re.sub('\W', '', name)[:20]
         if cls.is_service_reusable(story, line):
-            h = cls.hash_service_name(name)
+            h = cls.hash_service_name(story, name)
         else:
             h = cls.hash_service_name_and_story_line(story, line, name)
 
@@ -179,12 +179,14 @@ class Containers:
 
     @classmethod
     def hash_service_name_and_story_line(cls, story, line, name):
-        return hashlib.sha1(f'{name}-{story.name}-{line["ln"]}'
+        return hashlib.sha1(f'{name}-{story.app.version}-'
+                            f'{story.name}-{line["ln"]}'
                             .encode('utf-8')).hexdigest()
 
     @classmethod
-    def hash_service_name(cls, name):
-        return hashlib.sha1(f'{name}'.encode('utf-8')).hexdigest()
+    def hash_service_name(cls, story, name):
+        return hashlib.sha1(f'{name}-{story.app.version}'
+                            .encode('utf-8')).hexdigest()
 
     @classmethod
     def hash_volume_name(cls, story, line, service, volume_name):

--- a/tests/unit/Containers.py
+++ b/tests/unit/Containers.py
@@ -48,9 +48,10 @@ def test_is_service_reusable(story):
 def test_get_container_name(patch, story, line, reusable):
     patch.object(Containers, 'is_service_reusable', return_value=reusable)
     story.app.app_id = 'my_app'
+    story.app.version = 'v2'
     ret = Containers.get_container_name(story, line, 'alpine')
     if reusable:
-        assert ret == f'alpine-{Containers.hash_service_name("alpine")}'
+        assert ret == f'alpine-{Containers.hash_service_name(story, "alpine")}'
     else:
         h = Containers.hash_service_name_and_story_line(story, line, 'alpine')
         assert ret == f'alpine-{h}'
@@ -119,18 +120,21 @@ def test_hash_volume_name(patch, story, line, reusable):
 def test_service_name_and_story_line(patch, story):
     patch.object(hashlib, 'sha1')
     story.name = 'story_name'
+    story.app.version = 'v29'
     ret = Containers.hash_service_name_and_story_line(
         story, {'ln': '1'}, 'alpine')
 
-    hashlib.sha1.assert_called_with(f'alpine-{story.name}-1'.encode('utf-8'))
+    hashlib.sha1.assert_called_with(f'alpine-v29-{story.name}-1'
+                                    .encode('utf-8'))
     assert ret == hashlib.sha1().hexdigest()
 
 
-def test_service_name(patch):
+def test_service_name(patch, story):
+    story.app.version = 'v2'
     patch.object(hashlib, 'sha1')
-    ret = Containers.hash_service_name('alpine')
+    ret = Containers.hash_service_name(story, 'alpine')
 
-    hashlib.sha1.assert_called_with(f'alpine'.encode('utf-8'))
+    hashlib.sha1.assert_called_with(f'alpine-v2'.encode('utf-8'))
     assert ret == hashlib.sha1().hexdigest()
 
 


### PR DESCRIPTION
This is an experiment.
This is because apparently Kubernetes has trouble resolving DNS of a
pod that has been created, destroyed, and then created again with the
same name.