### PR TITLE
Use our technique of determining the next line after a foreach.

### DIFF
--- a/asyncy/processing/Lexicon.py
+++ b/asyncy/processing/Lexicon.py
@@ -217,7 +217,8 @@ class Lexicon:
             # Don't leak the variable to the outer scope.
             del story.context[output]
 
-        return line['exit']
+        # Use story.next_block(line), because line["exit"] is unreliable...
+        return Lexicon.line_number_or_none(story.next_block(line))
 
     @staticmethod
     async def when(logger, story, line):

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         'click==7.0',
         'frustum==0.0.6',
         'raven==6.9.0',
-        'storyscript==0.9.10',
+        'storyscript==0.9.14',
         'ujson==1.35',
         'certifi>=2018.8.24',
         'psycopg2==2.7.5',

--- a/tests/integration/processing/Lexicon.py
+++ b/tests/integration/processing/Lexicon.py
@@ -27,6 +27,20 @@ class TestCase:
 
 @mark.parametrize('suite', [  # See pydoc below for how this runs.
     TestSuite(
+        preparation_lines='labels = [{"name": "a"}]\n'
+                          'found = false',
+        cases=[
+            TestCase(
+                append='foreach labels as label\n'
+                       '   if label["name"] == "a" or label["name"] == "b"\n'
+                       '        found = true\n'
+                       'outside = true',
+                assertion=[ContextAssertion(key='found', expected=True),
+                           ContextAssertion(key='outside', expected=True)]
+            )
+        ]
+    ),
+    TestSuite(
         preparation_lines='a = 1\n'
                           'b = 5\n'
                           'c = null\n',

--- a/tests/unit/processing/Lexicon.py
+++ b/tests/unit/processing/Lexicon.py
@@ -337,7 +337,9 @@ async def test_lexicon_for_loop(patch, logger, story, line,
         return execute_block_return
 
     patch.object(Lexicon, 'execute', new=async_mock())
+    patch.object(Lexicon, 'line_number_or_none')
     patch.object(Story, 'execute_block', side_effect=execute_block)
+    patch.object(story, 'next_block')
 
     line['args'] = [
         {'$OBJECT': 'path', 'paths': ['elements']}
@@ -351,13 +353,13 @@ async def test_lexicon_for_loop(patch, logger, story, line,
 
     if execute_block_return == LineSentinels.BREAK:
         assert iterated_over_items == ['one']
-        assert result == line['exit']
+        assert result == Lexicon.line_number_or_none(story.next_block(line))
     elif LineSentinels.is_sentinel(execute_block_return):
         assert iterated_over_items == ['one']
         assert result == execute_block_return
     else:
         assert iterated_over_items == story.context['elements']
-        assert result == line['exit']
+        assert result == Lexicon.line_number_or_none(story.next_block(line))
 
     # Ensure no leakage of the element
     assert story.context.get('element') is None


### PR DESCRIPTION
Why? Because Storyscript's line["exit"] doesn't work properly.