### PR TITLE
Copy output from when blocks only.

### DIFF
--- a/asyncy/processing/Story.py
+++ b/asyncy/processing/Story.py
@@ -121,7 +121,8 @@ class Story:
 
         # If this block represents a streaming service, copy over it's
         # output to the context, so that Lexicon can read it later.
-        if parent_line.get('output') is not None:
+        if parent_line.get('output') is not None \
+                and parent_line.get('method') == 'when':
             story.context[ContextConstants.service_output] = \
                 parent_line['output'][0]
 

--- a/tests/unit/processing/Story.py
+++ b/tests/unit/processing/Story.py
@@ -140,7 +140,8 @@ async def test_story_execute_block(patch, logger, story,
                                    async_mock, line_4_result):
     story.tree = {
         '1': {'ln': '1', 'next': '2'},
-        '2': {'ln': '2', 'next': '3', 'enter': '3', 'output': ['foo_client']},
+        '2': {'ln': '2', 'next': '3', 'enter': '3',
+              'output': ['foo_client'], 'method': 'when'},
         '3': {'ln': '3', 'next': '4', 'parent': '2'},
         '4': {'ln': '4', 'next': '5', 'parent': '2'},
         '5': {'ln': '5', 'next': '6', 'parent': '2'},


### PR DESCRIPTION
If we copy the output from all blocks, then foreach is affected.